### PR TITLE
Add basic frontend chat UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,13 @@ The project uses Azure-hosted models when corresponding environment variables ar
 
 ## Agentic Core
 LangGraph is used throughout the `core` modules to manage short- and long-term memory as well as high level planning. These graphs can call Azure endpoints for tasks like summarization or classification, allowing flexible orchestration across services.
+
+## Frontend Usage
+The `frontend/` directory contains a minimal WebSocket chat interface. After starting the API server you can serve the static files using Python's built in HTTP server:
+
+```bash
+# from the repository root
+python -m http.server --directory frontend 8080
+```
+
+Then open `http://localhost:8080` in your browser. The page lets you send text messages over the WebSocket and upload files through the `/upload` endpoint.

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -1,0 +1,32 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 20px;
+    background-color: #f5f5f5;
+}
+
+#chat-container {
+    max-width: 600px;
+    margin: auto;
+    background: #fff;
+    padding: 20px;
+    border-radius: 4px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+#messages {
+    height: 300px;
+    overflow-y: auto;
+    border: 1px solid #ccc;
+    padding: 10px;
+    margin-bottom: 10px;
+}
+
+.message {
+    margin-bottom: 8px;
+}
+
+.message.system {
+    color: #666;
+    font-style: italic;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SuperAgent Chat</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <div id="chat-container">
+        <div id="messages"></div>
+        <form id="text-form">
+            <input type="text" id="text-input" placeholder="Type a message" autocomplete="off" required>
+            <button type="submit">Send</button>
+        </form>
+        <form id="file-form">
+            <input type="file" id="file-input">
+            <button type="submit">Upload</button>
+        </form>
+    </div>
+    <script src="js/chat.js"></script>
+</body>
+</html>

--- a/frontend/js/chat.js
+++ b/frontend/js/chat.js
@@ -1,0 +1,62 @@
+(function() {
+    const ws = new WebSocket(`ws://${location.host}/ws`);
+    const messagesEl = document.getElementById('messages');
+    const textForm = document.getElementById('text-form');
+    const textInput = document.getElementById('text-input');
+    const fileForm = document.getElementById('file-form');
+    const fileInput = document.getElementById('file-input');
+
+    function appendMessage(text, cls) {
+        const div = document.createElement('div');
+        div.textContent = text;
+        div.className = 'message ' + (cls || '');
+        messagesEl.appendChild(div);
+        messagesEl.scrollTop = messagesEl.scrollHeight;
+    }
+
+    ws.addEventListener('open', () => {
+        appendMessage('WebSocket connected', 'system');
+    });
+
+    ws.addEventListener('message', (event) => {
+        try {
+            const data = JSON.parse(event.data);
+            appendMessage('Agent: ' + (data.result || data.message));
+        } catch (e) {
+            appendMessage('Received: ' + event.data);
+        }
+    });
+
+    ws.addEventListener('close', () => {
+        appendMessage('WebSocket disconnected', 'system');
+    });
+
+    textForm.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const text = textInput.value.trim();
+        if (!text) return;
+        appendMessage('You: ' + text);
+        ws.send(JSON.stringify({ content: text }));
+        textInput.value = '';
+    });
+
+    fileForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const file = fileInput.files[0];
+        if (!file) return;
+        appendMessage('Uploading: ' + file.name, 'system');
+        const formData = new FormData();
+        formData.append('file', file);
+        try {
+            const response = await fetch('/upload', {
+                method: 'POST',
+                body: formData
+            });
+            const data = await response.json();
+            appendMessage('Agent: ' + (data.result || data.message));
+        } catch (err) {
+            appendMessage('Upload failed', 'system');
+        }
+        fileInput.value = '';
+    });
+})();


### PR DESCRIPTION
## Summary
- add a minimal frontend subdirectory with HTML/CSS/JS for chatting via WebSocket and uploading files
- document how to use the frontend in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d5ec9a208832cbdd422ad1662c941