### PR TITLE
Add React frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,13 @@ python -m http.server --directory frontend 8080
 ```
 
 Then open `http://localhost:8080` in your browser. The page lets you send text messages over the WebSocket and upload files through the `/upload` endpoint.
+
+### React Interface
+If you prefer a React-based frontend, open the files under `frontend/react`. Serve them with Python as well:
+
+```bash
+# from the repository root
+python -m http.server --directory frontend/react 8090
+```
+
+Visit `http://localhost:8090` to use the React chat client.

--- a/frontend/react/index.html
+++ b/frontend/react/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SuperAgent React Chat</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="root"></div>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <script type="module" src="js/app.js"></script>
+</body>
+</html>
+

--- a/frontend/react/js/app.js
+++ b/frontend/react/js/app.js
@@ -1,0 +1,97 @@
+const { useState, useEffect, useRef } = React;
+
+function App() {
+  const [messages, setMessages] = useState([]);
+  const [text, setText] = useState('');
+  const [file, setFile] = useState(null);
+  const wsRef = useRef(null);
+  const messagesEndRef = useRef(null);
+
+  useEffect(() => {
+    wsRef.current = new WebSocket(`ws://${location.host}/ws`);
+    const ws = wsRef.current;
+
+    function addMessage(msg, cls) {
+      setMessages(m => [...m, { text: msg, cls }]);
+    }
+
+    ws.addEventListener('open', () => {
+      addMessage('WebSocket connected', 'system');
+    });
+
+    ws.addEventListener('message', event => {
+      try {
+        const data = JSON.parse(event.data);
+        addMessage('Agent: ' + (data.result || data.message));
+      } catch (e) {
+        addMessage('Received: ' + event.data);
+      }
+    });
+
+    ws.addEventListener('close', () => {
+      addMessage('WebSocket disconnected', 'system');
+    });
+
+    return () => ws.close();
+  }, []);
+
+  useEffect(() => {
+    if (messagesEndRef.current) {
+      messagesEndRef.current.scrollTop = messagesEndRef.current.scrollHeight;
+    }
+  }, [messages]);
+
+  const sendMessage = e => {
+    e.preventDefault();
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    setMessages(m => [...m, { text: 'You: ' + trimmed }]);
+    wsRef.current.send(JSON.stringify({ content: trimmed }));
+    setText('');
+  };
+
+  const uploadFile = async e => {
+    e.preventDefault();
+    if (!file) return;
+    setMessages(m => [...m, { text: 'Uploading: ' + file.name, cls: 'system' }]);
+    const formData = new FormData();
+    formData.append('file', file);
+    try {
+      const response = await fetch('/upload', { method: 'POST', body: formData });
+      const data = await response.json();
+      setMessages(m => [...m, { text: 'Agent: ' + (data.result || data.message) }]);
+    } catch(err) {
+      setMessages(m => [...m, { text: 'Upload failed', cls: 'system' }]);
+    }
+    setFile(null);
+    e.target.reset();
+  };
+
+  return (
+    React.createElement('div', { id: 'chat-container' },
+      React.createElement('div', { id: 'messages', ref: messagesEndRef },
+        messages.map((m, i) => React.createElement('div', { key: i, className: 'message ' + (m.cls || '') }, m.text))
+      ),
+      React.createElement('form', { onSubmit: sendMessage, id: 'text-form' },
+        React.createElement('input', {
+          type: 'text',
+          value: text,
+          onChange: e => setText(e.target.value),
+          id: 'text-input'
+        }),
+        React.createElement('button', { type: 'submit' }, 'Send')
+      ),
+      React.createElement('form', { onSubmit: uploadFile, id: 'file-form' },
+        React.createElement('input', {
+          type: 'file',
+          onChange: e => setFile(e.target.files[0]),
+          id: 'file-input'
+        }),
+        React.createElement('button', { type: 'submit' }, 'Upload')
+      )
+    )
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(App));
+

--- a/frontend/react/style.css
+++ b/frontend/react/style.css
@@ -1,0 +1,33 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 20px;
+    background-color: #f5f5f5;
+}
+
+#chat-container {
+    max-width: 600px;
+    margin: auto;
+    background: #fff;
+    padding: 20px;
+    border-radius: 4px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+#messages {
+    height: 300px;
+    overflow-y: auto;
+    border: 1px solid #ccc;
+    padding: 10px;
+    margin-bottom: 10px;
+}
+
+.message {
+    margin-bottom: 8px;
+}
+
+.message.system {
+    color: #666;
+    font-style: italic;
+}
+


### PR DESCRIPTION
## Summary
- add new React-based chat client under `frontend/react`
- update README with instructions for using the React interface

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a2e0adb50832ca3ed74561e0ba2fe