### PR TITLE
Add Cosmos DB logging for conversations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pypdf
 pandas
 requests
 google-generativeai
+azure-cosmos

--- a/src/services/cosmos_client.py
+++ b/src/services/cosmos_client.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+import uuid
+
+try:
+    from azure.cosmos import CosmosClient, PartitionKey
+except Exception:  # pragma: no cover - cosmos optional
+    CosmosClient = None
+    PartitionKey = None
+
+
+class CosmosConversationLogger:
+    """Store conversation messages in Azure Cosmos DB."""
+
+    def __init__(self, connection_str: str, database: str, container: str) -> None:
+        if CosmosClient is None:
+            raise ImportError("azure-cosmos is required for CosmosConversationLogger")
+        self.client = CosmosClient.from_connection_string(connection_str)
+        self.database = self.client.create_database_if_not_exists(database)
+        self.container = self.database.create_container_if_not_exists(
+            id=container,
+            partition_key=PartitionKey(path="/conversation_id"),
+        )
+
+    def log_message(self, conversation_id: str, role: str, content: Any) -> None:
+        item = {
+            "id": str(uuid.uuid4()),
+            "conversation_id": conversation_id,
+            "role": role,
+            "content": content,
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+        self.container.upsert_item(item)


### PR DESCRIPTION
## Summary
- implement `CosmosConversationLogger` for storing messages in Azure Cosmos DB
- integrate optional Cosmos logging into `RouterAgent`
- add `azure-cosmos` to requirements
- ensure tests pass

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874882c31ac832c80bd55c55dd18a0f